### PR TITLE
Fix error state handling in custom fetch hook

### DIFF
--- a/week3/src/hooks/useCustomFetch.tsx
+++ b/week3/src/hooks/useCustomFetch.tsx
@@ -16,6 +16,7 @@ function useCustomFetch<T>(url: string, language:Language="en-US"): ApiResponse<
     useEffect(() => {
         const fetchData = async () => {
             setIsPending(true);
+            setIsError(false);
             try {
                 const { data } = await axios.get<T>(url, {
                     headers: {


### PR DESCRIPTION
## Summary
- ensure `useCustomFetch` resets error state before each request

## Testing
- `npm run build` *(fails: Cannot find module '@eslint/js' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684acd06ba0083338c4834b2e1df4f1d